### PR TITLE
A Few Small Fixups

### DIFF
--- a/Desktop/App.xaml.cs
+++ b/Desktop/App.xaml.cs
@@ -5,6 +5,10 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using ReactiveFlickr;
+using ReactiveFlickr.Desktop;
+using ReactiveUI;
+using Splat;
 
 namespace FlickrSearch
 {
@@ -13,5 +17,9 @@ namespace FlickrSearch
     /// </summary>
     public partial class App : Application
     {
+        public App()
+        {
+            Locator.CurrentMutable.Register(() => new ImageTileView(), typeof(IViewFor<SearchResultViewModel>));
+        }
     }
 }

--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -74,6 +74,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="ImageTileView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -84,6 +88,9 @@
     </Compile>
     <Compile Include="BitmapSourceConverter.cs" />
     <Compile Include="BoolToVisibilityConverter.cs" />
+    <Compile Include="ImageTileView.xaml.cs">
+      <DependentUpon>ImageTileView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Desktop/ImageTileView.xaml
+++ b/Desktop/ImageTileView.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="ReactiveFlickr.Desktop.ImageTileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+
+    <Image x:Name="ImageHost" 
+           Height="150" Width="150"/>
+</UserControl>

--- a/Desktop/ImageTileView.xaml.cs
+++ b/Desktop/ImageTileView.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using ReactiveUI;
+using Splat;
+
+namespace ReactiveFlickr.Desktop
+{
+    /// <summary>
+    /// Interaction logic for ImageTile.xaml
+    /// </summary>
+    public partial class ImageTileView : UserControl, IViewFor<SearchResultViewModel>
+    {
+        public ImageTileView()
+        {
+            InitializeComponent();
+
+            this.WhenAny(x => x.ViewModel.Image, x => x.Value.ToNative())
+                .BindTo(this, x => x.ImageHost.Source);
+
+            this.OneWayBind(ViewModel, vm => vm.Title, v => v.ImageHost.ToolTip);
+        }
+
+        public SearchResultViewModel ViewModel {
+            get { return (SearchResultViewModel)GetValue(ViewModelProperty); }
+            set { SetValue(ViewModelProperty, value); }
+        }
+        public static readonly DependencyProperty ViewModelProperty =
+            DependencyProperty.Register("ViewModel", typeof(SearchResultViewModel), typeof(ImageTileView), new PropertyMetadata(null));
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (SearchResultViewModel)value; }
+        }
+    }
+}

--- a/Desktop/ImageTileView.xaml.cs
+++ b/Desktop/ImageTileView.xaml.cs
@@ -27,10 +27,12 @@ namespace ReactiveFlickr.Desktop
         {
             InitializeComponent();
 
-            this.WhenAny(x => x.ViewModel.Image, x => x.Value.ToNative())
-                .BindTo(this, x => x.ImageHost.Source);
+            this.WhenActivated(d => {
+                d(this.WhenAny(x => x.ViewModel.Image, x => x.Value.ToNative())
+                    .BindTo(this, x => x.ImageHost.Source));
 
-            this.OneWayBind(ViewModel, vm => vm.Title, v => v.ImageHost.ToolTip);
+                d(this.OneWayBind(ViewModel, vm => vm.Title, v => v.ImageHost.ToolTip));
+            });
         }
 
         public SearchResultViewModel ViewModel {

--- a/Desktop/MainWindow.xaml
+++ b/Desktop/MainWindow.xaml
@@ -29,34 +29,28 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <TextBox
-                Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                IsEnabled="{Binding CanEnterSearchText}"
+            <TextBox x:Name="SearchText"
                 Padding="4,0"
                 FontSize="20"
                 Margin="0, 0, 10, 0" />
             
-            <Button Grid.Column="1"
+            <Button x:Name="Search"
+                    Grid.Column="1"
                     Padding="4"
-                    Content="Search"
-                    Command="{Binding Search}" />
-            
+                    Content="Search" />
         </Grid>
 
-        <ProgressBar Grid.Row="1"
+        <ProgressBar x:Name="IsLoading"
+                     Grid.Row="1"
                      Foreground="Blue"
                      Background="White"
-                     IsIndeterminate="True"
-                     Visibility="{Binding IsLoading, Converter={StaticResource boolToVisibilityConverter}}" />
+                     IsIndeterminate="True" />
 
-        <ItemsControl Grid.Row="2"
-                      ItemsSource="{Binding Images}"
-                      ItemTemplate="{StaticResource imageTemplate}"
+        <ItemsControl x:Name="Images" Grid.Row="2"
                       Template="{StaticResource scrollViewTemplate}"
                       ItemsPanel="{StaticResource gridViewTemplate}" />
 
-        <Grid Grid.Row="2"
-                    Visibility="{Binding ShowError, Converter={StaticResource boolToVisibilityConverter}}"
+        <Grid Grid.Row="2" x:Name="ShowError"
                     Background="#D0FFFFFF">
             <StackPanel HorizontalAlignment="Center"
                         VerticalAlignment="Center">

--- a/Desktop/MainWindow.xaml
+++ b/Desktop/MainWindow.xaml
@@ -2,23 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:Desktop="clr-namespace:ReactiveFlickr.Desktop"
-        xmlns:ReactiveFlickr="clr-namespace:ReactiveFlickr;assembly=ReactiveFlickr"
-        mc:Ignorable="d"
-        d:DataContext="{d:DesignInstance ReactiveFlickr:FlickrSearchViewModel}"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
         Title="ReactiveFlickr" Height="538" Width="633">
     
     <Window.Resources>
-        <Desktop:BoolToVisibilityConverter x:Key="boolToVisibilityConverter" />
-        <Desktop:BitmapSourceConverter x:Key="bitmapSourceConverter" />
-        
-        <DataTemplate x:Key="imageTemplate">
-            <Image Source="{Binding Image, Converter={StaticResource bitmapSourceConverter}}"
-                   Height="150"
-                   Width="150"
-                   ToolTip="{Binding Title}" />
-        </DataTemplate>
         <ControlTemplate x:Key="scrollViewTemplate">
             <ScrollViewer>
                 <ItemsPresenter />
@@ -27,7 +14,6 @@
         <ItemsPanelTemplate x:Key="gridViewTemplate">
             <WrapPanel IsItemsHost="True" />
         </ItemsPanelTemplate>
-        
     </Window.Resources>
 
     <Grid>

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -1,17 +1,31 @@
 ﻿using System.Windows;
+using ReactiveUI;
 
 namespace ReactiveFlickr.Desktop
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    public partial class MainWindow : Window, IViewFor<FlickrSearchViewModel>
     {
         public MainWindow()
         {
             InitializeComponent();
+
             var service = new FlickrImageService();
-            DataContext = new FlickrSearchViewModel(service);
+            ViewModel = new FlickrSearchViewModel(service);
+        }
+
+        public FlickrSearchViewModel ViewModel {
+            get { return (FlickrSearchViewModel)GetValue(ViewModelProperty); }
+            set { SetValue(ViewModelProperty, value); }
+        }
+        public static readonly DependencyProperty ViewModelProperty =
+            DependencyProperty.Register("ViewModel", typeof(FlickrSearchViewModel), typeof(MainWindow), new PropertyMetadata(null));
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (FlickrSearchViewModel)value; }
         }
     }
 }

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -14,6 +14,19 @@ namespace ReactiveFlickr.Desktop
 
             var service = new FlickrImageService();
             ViewModel = new FlickrSearchViewModel(service);
+
+            this.Bind(ViewModel, vm => vm.SearchText, v => v.SearchText.Text);
+            this.OneWayBind(ViewModel, vm => vm.CanEnterSearchText, v => v.SearchText.IsEnabled);
+            this.BindCommand(ViewModel, vm => vm.Search, v => v.Search);
+
+            this.OneWayBind(ViewModel, vm => vm.IsLoading, v => v.IsLoading.Visibility);
+
+            // NB: Because Images doesn't have an ItemTemplate, ReactiveUI will 
+            // give you one Automagically, that will look up Views based on their
+            // IViewFor<ViewModel> type
+            this.OneWayBind(ViewModel, vm => vm.Images, v => v.Images.ItemsSource);
+
+            this.OneWayBind(ViewModel, vm => vm.ShowError, v => v.ShowError.Visibility);
         }
 
         public FlickrSearchViewModel ViewModel {

--- a/Test/FlickrSearchViewModelTests.cs
+++ b/Test/FlickrSearchViewModelTests.cs
@@ -3,6 +3,7 @@ using NSubstitute;
 using Splat;
 using System;
 using System.Reactive.Linq;
+using System.Reactive.Disposables;
 
 namespace ReactiveFlickr.Test
 {
@@ -202,13 +203,7 @@ namespace ReactiveFlickr.Test
 
                 var service = Substitute.For<IImageService>();
                 service.GetImages(Arg.Any<string>())
-                    .Returns(
-                        Observable.Create<SearchResultViewModel>(async obs =>
-                        {
-                            obs.OnNext(photo1);
-                            obs.OnNext(photo2);
-                            obs.OnCompleted();
-                        }));
+                    .Returns(new[] { photo1, photo2, }.ToObservable());
 
                 subject = new FlickrSearchViewModel(service)
                 {


### PR DESCRIPTION
I added a few things to this great example, feel free to take them en-masse, or cherry pick the ones you like. The biggest one being that I made the WPF example use RxUI bindings instead of XAML bindings, which takes a lot of text cruft out of the XAML (making it more focused on actual visuals), as well as adding type-safety - if you rename a ViewModel property, the build no longer works.

This PR also takes advantage of ReactiveUI's Auto DataTemplate feature, where if you register an `IViewFor<ViewModel>` for an ItemsControl, you don't have to provide a data template. Feels a bit Overkill here, but it was a good example. 
